### PR TITLE
Standardize payment scope middleware and error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"cors": "^2.8.5",
 				"express": "^5.1.0",
 				"express-session": "^1.18.1",
 				"jsonwebtoken": "^9.0.2",
@@ -311,6 +312,19 @@
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
 			"integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
 			"license": "MIT"
+		},
+		"node_modules/cors": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
 		},
 		"node_modules/data-uri-to-buffer": {
 			"version": "6.0.2",
@@ -1258,6 +1272,15 @@
 			"optional": true,
 			"engines": {
 				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"start": "node server.js"
 	},
 	"dependencies": {
+		"cors": "^2.8.5",
 		"express": "^5.1.0",
 		"express-session": "^1.18.1",
 		"jsonwebtoken": "^9.0.2",

--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ function checkPaymentScope(req, res, next) {
 app.use(checkPaymentScope);
 
 // Middleware para verificar o scope app-payment-scope
-function checkPaymentScopeRote(req, res, next) {
+function checkPaymentScopeRoute(req, res, next) {
 	// Primeiro verifica se o token é válido
 	keycloak.protect()(req, res, (error) => {
 		if (error) {
@@ -74,7 +74,7 @@ function checkPaymentScopeRote(req, res, next) {
 	});
 }
 
-app.get("/checkscoperoute", checkPaymentScopeRote, (req, res) => {
+app.get("/checkscoperoute", checkPaymentScopeRoute, (req, res) => {
 	res.json({
 		message: "Rota protegida!",
 		required: "app-payment-scope",

--- a/server.js
+++ b/server.js
@@ -25,21 +25,23 @@ const nonProtectedRoutes = ["/logoff", "/callbacks"];
 
 function checkPaymentScope(req, res, next) {
 	keycloak.protect()(req, res, (error) => {
-		if (error) return res.status(401).json({ error: 'Unauthorized' });
+		if (error) return res.status(401).json({ error: "Unauthorized" });
 
 		if (nonProtectedRoutes.includes(req.path)) {
 			return next();
 		}
 
 		const token = req.kauth.grant.access_token;
-		const scopes = token.content.scope || '';
+		const scopes = token.content.scope || "";
 		const roles = token.content.realm_access?.roles || []; //
 
-		if (scopes.split(' ').includes('app-payment-scope')) {
+		if (scopes.split(" ").includes("app-payment-scope")) {
 			return next();
 		}
 
-		return res.status(403).json({ error: 'Forbidden - Missing required scope' });
+		return res
+			.status(403)
+			.json({ error: "Forbidden - Missing required scope" });
 	});
 }
 
@@ -51,68 +53,89 @@ function checkPaymentScopeRote(req, res, next) {
 	// Primeiro verifica se o token é válido
 	keycloak.protect()(req, res, (error) => {
 		if (error) {
-			return res.status(401).json({ error: 'Unauthorized' });
+			return res.status(401).json({ error: "Unauthorized" });
 		}
 
 		const token = req.kauth.grant.access_token;
-		const scopes = token.content.scope || '';
+		const scopes = token.content.scope || "";
 		const roles = token.content.realm_access?.roles || []; //
 
-		if (scopes.split(' ').includes('app-payment-scope')) {
+		if (scopes.split(" ").includes("app-payment-scope")) {
 			return next();
 		}
 
 		// Scope não encontrado
-		return res.status(403).json({ error: 'Forbidden - Missing required scope' });
+		return res
+			.status(403)
+			.json({ error: "Forbidden - Missing required scope" });
 	});
 }
 
-app.get("/testuses", checkPaymentScopeRote, (req, res) => {
-	res.send("This is a protected route user with the correct scope");
+app.get("/checkscoperoute", checkPaymentScopeRote, (req, res) => {
+	res.json({
+		message: "Rota protegida!",
+		required: "app-payment-scope",
+		middleware: checkPaymentScopeRote.name,
+		path: req.path,
+		scopes: req.kauth.grant.access_token.content.scope.split(" "),
+	});
 });
 
-app.get("/complain", keycloak.protect(), (req, res) => {
-	res.send("This is a protected route");
+app.get("/checkprotect", keycloak.protect(), (req, res) => {
+	res.json({
+		message: "Rota protegida!",
+		required: "app-payment-scope",
+		middleware: checkPaymentScope.name,
+		path: req.path,
+		scopes: req.kauth.grant.access_token.content.scope.split(" "),
+	});
 });
 
-app.get("/user", keycloak.protect("realm:user"), (req, res) => {
-	res.send("This is a protected route user");
+app.get("/checkroleuser", keycloak.protect("realm:user"), (req, res) => {
+	res.json({
+		message: "Rota protegida!",
+		required: "app-payment-scope",
+		middleware: checkPaymentScope.name,
+		path: req.path,
+		scopes: req.kauth.grant.access_token.content.scope.split(" "),
+		roles: req.kauth.grant.access_token.content.realm_access.roles,
+	});
 });
 
-app.get("/administrator", keycloak.protect("realm:admin"), (req, res) => {
-	res.send("This is a protected route user");
+app.get("/checkroleadmin", keycloak.protect("realm:admin"), (req, res) => {
+	res.json({
+		message: "Rota protegida!",
+		required: "app-payment-scope",
+		middleware: checkPaymentScope.name,
+		path: req.path,
+		scopes: req.kauth.grant.access_token.content.scope.split(" "),
+		roles: req.kauth.grant.access_token.content.realm_access.roles,
+	});
 });
 
-app.get("/all", keycloak.protect(["realm:user", "realm:admin"]), (req, res) => {
-	res.send("This is a protected route user");
+app.get("/checkroles", keycloak.protect(["realm:user", "realm:admin"]), (req, res) => {
+	res.json({
+		message: "Rota protegida!",
+		required: "app-payment-scope",
+		middleware: checkPaymentScope.name,
+		path: req.path,
+		scopes: req.kauth.grant.access_token.content.scope.split(" "),
+		roles: req.kauth.grant.access_token.content.realm_access.roles,
+	});
 });
 
-app.get("/protected", keycloak.protect(), (req, res) => {
-	const tokenContent = req.kauth.grant.access_token.content;
-	const scope = tokenContent.scope;
-	res.json({ message: "Rota protegida!", scopes: scope.split(" ") });
+app.get("/checkscopes", keycloak.protect(), (req, res) => {
+	res.json({
+		message: "Rota protegida!",
+		required: "app-payment-scope",
+		middleware: checkPaymentScope.name,
+		path: req.path,
+		scopes: req.kauth.grant.access_token.content.scope.split(" "),
+		roles: req.kauth.grant.access_token.content.realm_access.roles,
+	});
 });
 
-app.get("/scope", keycloak.protect(), (req, res) => {
-	const tokenContent = req.kauth.grant.access_token.content;
-	const scopes = tokenContent.scope.split(" ");
-
-	if (scopes.includes("app-payment-scope")) {
-		res.send("This is a protected route user with the correct scope");
-	} else {
-		res.status(403).send("Forbidden: Insufficient scope");
-	}
-});
-
-app.get(
-	"/scopeenforced",
-	keycloak.enforcer("scope:app-payment-scope"),
-	(req, res) => {
-		res.send("This is a protected route user with the correct scope");
-	},
-);
-
-app.get('/logout', (req, res) => {
+app.get("/logout", (req, res) => {
 	keycloak.logout()(req, res);
 });
 

--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ function checkPaymentScope(req, res, next) {
 app.use(checkPaymentScope);
 
 // Middleware para verificar o scope app-payment-scope
-function checkPaymentScopeUse(req, res, next) {
+function checkPaymentScopeRote(req, res, next) {
 	// Primeiro verifica se o token é válido
 	keycloak.protect()(req, res, (error) => {
 		if (error) {
@@ -67,7 +67,7 @@ function checkPaymentScopeUse(req, res, next) {
 	});
 }
 
-app.get("/testuses", checkPaymentScopeUse, (req, res) => {
+app.get("/testuses", checkPaymentScopeRote, (req, res) => {
 	res.send("This is a protected route user with the correct scope");
 });
 

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const session = require("express-session");
 const Keycloak = require("keycloak-connect");
 const express = require("express");
+const cors = require("cors");
 const app = express();
 
 const memoryStore = new session.MemoryStore();
@@ -20,6 +21,8 @@ const keycloak = new Keycloak({
 });
 
 app.use(keycloak.middleware());
+
+app.use(cors())
 
 const nonProtectedRoutes = ["/logoff", "/callbacks"];
 


### PR DESCRIPTION
Rename the `checkPaymentScopeUse` function to `checkPaymentScopeRote` for consistency. Standardize error messages and enhance the scope checking logic in the middleware.